### PR TITLE
Ducksパターンを用いて簡単なcounterを実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^16.4.2",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
+    "redux-actions": "^2.6.1",
     "redux-devtools-extension": "^2.13.5",
     "redux-thunk": "^2.3.0",
     "universal-cookie": "^3.0.0"
@@ -38,6 +39,7 @@
     "@types/next-redux-wrapper": "^2.0.0",
     "@types/react": "^16.4.11",
     "@types/react-redux": "^6.0.6",
+    "@types/redux-actions": "^2.3.0",
     "@zeit/next-typescript": "^1.1.0",
     "prettier": "^1.14.2",
     "tslint": "^5.11.0",

--- a/src/components/Counter.tsx
+++ b/src/components/Counter.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { ActionDispatcher } from "../containers/Counter";
+import { ICounterState } from "../modules/Counter";
+
+interface IProps {
+  value: ICounterState;
+  actions: ActionDispatcher;
+}
+
+export const Counter: React.SFC<IProps> = (props: IProps) => {
+  const incrementClickHandler = async () => {
+    await props.actions.increment();
+  };
+  const decrementClickHandler = async () => {
+    await props.actions.decrement();
+  };
+
+  return (
+    <>
+      <p>{props.value.count}</p>
+      <button onClick={incrementClickHandler}>increment!</button>
+      <button onClick={decrementClickHandler}>decrement!</button>
+    </>
+  );
+};
+
+export default Counter;

--- a/src/containers/Counter.ts
+++ b/src/containers/Counter.ts
@@ -1,0 +1,54 @@
+import { ICounterState, counterActions } from "../modules/Counter";
+import { Dispatch } from "redux";
+import { connect, MapDispatchToProps, MapStateToProps } from "react-redux";
+import Counter from "../components/Counter";
+import { IReduxState, ReduxAction } from "../store";
+
+const sleep = microSecond =>
+  new Promise(resolve => setTimeout(resolve, microSecond));
+
+export class ActionDispatcher {
+  private readonly dispatch: (action: any) => void;
+
+  constructor(dispatch) {
+    this.dispatch = dispatch;
+  }
+
+  async increment() {
+    await sleep(1000);
+
+    this.dispatch(counterActions.increment());
+
+    return;
+  }
+
+  async decrement() {
+    await sleep(1000);
+
+    this.dispatch(counterActions.decrement());
+
+    return;
+  }
+}
+
+const mapStateToProps: MapStateToProps<{ value: ICounterState }, any, any> = (
+  state: IReduxState
+) => {
+  return {
+    value: state.counter
+  };
+};
+
+const mapDispatchToProps: MapDispatchToProps<
+  { actions: ActionDispatcher },
+  {}
+> = (dispatch: Dispatch<ReduxAction>) => {
+  return {
+    actions: new ActionDispatcher(dispatch)
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Counter);

--- a/src/modules/Counter.ts
+++ b/src/modules/Counter.ts
@@ -1,0 +1,55 @@
+import { Action } from "redux-actions";
+
+enum ActionType {
+  increment = "INCREMENT",
+  decrement = "DECREMENT"
+}
+
+export type CounterAction = Action<{}> | Action<{}>;
+
+const increment = (): CounterAction => {
+  return {
+    type: ActionType.increment,
+    payload: {},
+    error: false
+  };
+};
+const decrement = (): CounterAction => {
+  return {
+    type: ActionType.decrement,
+    payload: {},
+    error: false
+  };
+};
+
+export const counterActions = { increment, decrement };
+
+export interface ICounterState {
+  count: number;
+}
+
+const initialState: ICounterState = {
+  count: 0
+};
+
+export const reducer = (
+  state: ICounterState = initialState,
+  action: CounterAction
+): ICounterState => {
+  switch (action.type) {
+    case ActionType.increment:
+      return {
+        ...state,
+        count: state.count + 1
+      };
+    case ActionType.decrement:
+      return {
+        ...state,
+        count: state.count - 1
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { Provider } from "react-redux";
 import App, { AppComponentProps, Container } from "next/app";
 import withRedux from "next-redux-wrapper";
-import { initStore } from "../store";
+import initStore, { IReduxState } from "../store";
+import { Store } from "redux";
 
 interface IProps extends AppComponentProps {
-  // TODO 型定義を行う
-  store: any;
+  store: Store<IReduxState>;
 }
 
 export default withRedux(initStore)(

--- a/src/pages/counter.tsx
+++ b/src/pages/counter.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { ICounterState } from "../modules/Counter";
+import Counter, { ActionDispatcher } from "../containers/Counter";
+
+interface IProps {
+  value: ICounterState;
+  actions: ActionDispatcher;
+}
+
+export const CounterPage: React.SFC<IProps> = (props: IProps) => {
+  return (
+    <>
+      <Counter actions={props.actions} value={props.value} />
+    </>
+  );
+};
+
+export default CounterPage;

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,12 +1,22 @@
-import { createStore, applyMiddleware } from "redux";
+import { createStore, combineReducers } from "redux";
+import counter, { CounterAction, ICounterState } from "./modules/Counter";
+import { Action } from "redux-actions";
 import { composeWithDevTools } from "redux-devtools-extension";
-import thunkMiddleware from "redux-thunk";
-import { reducer } from "./states/announcement/reducer";
 
-export const initStore = initialState => {
+export interface IReduxState {
+  counter: ICounterState;
+}
+
+export type ReduxAction = CounterAction | Action<any>;
+
+export const initStore = (initialState = { counter: { count: 0 } }) => {
   return createStore(
-    reducer,
+    combineReducers({
+      counter
+    }),
     initialState,
-    composeWithDevTools(applyMiddleware(thunkMiddleware))
+    composeWithDevTools()
   );
 };
+
+export default initStore;

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,6 +676,10 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/redux-actions@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@types/redux-actions/-/redux-actions-2.3.0.tgz#d28d7913ec86ee9e20ecb33a1fed887ecb538149"
+
 "@zeit/next-typescript@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@zeit/next-typescript/-/next-typescript-1.1.0.tgz#57a45c85c336fee8d71c1bd966195565016932b2"
@@ -2310,7 +2314,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -2653,6 +2657,14 @@ locate-path@^2.0.0:
 lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
+lodash.curry@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -3585,6 +3597,19 @@ recursive-copy@2.0.6:
     pify "^2.3.0"
     promise "^7.0.1"
     slash "^1.0.0"
+
+reduce-reducers@^0.1.0:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/reduce-reducers/-/reduce-reducers-0.1.5.tgz#ff77ca8068ff41007319b8b4b91533c7e0e54576"
+
+redux-actions@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/redux-actions/-/redux-actions-2.6.1.tgz#42c06e94739fbe6db35db3605abb105bdb3724d8"
+  dependencies:
+    invariant "^2.2.1"
+    lodash.camelcase "^4.3.0"
+    lodash.curry "^4.1.1"
+    reduce-reducers "^0.1.0"
 
 redux-devtools-extension@^2.13.5:
   version "2.13.5"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/redux-next-boilerplate/issues/7

# やった事
表題の通り。
これで複数のreducer（つまり複数ページ）が存在しても対応可能になった。

まだまだコードが粗い部分が多いので次回以降のPRで修正を行う。