### PR TITLE
getInitialPropsで取得したユーザーと検索したユーザー情報が2つ表示されてしまう問題を解決

### DIFF
--- a/src/domain/Qiita.ts
+++ b/src/domain/Qiita.ts
@@ -20,12 +20,7 @@ export const fetchUser = async (
 ): Promise<IFetchQiitaUserResponse> => {
   return axios
     .get<IFetchQiitaUserResponse>(
-      `https://qiita.com/api/v2/users/${request.id}`,
-      {
-        headers: {
-          Authorization: "Bearer d78f582769a5c5ad556e73d495caf1823c75f280"
-        }
-      }
+      `https://qiita.com/api/v2/users/${request.id}`
     )
     .then((axiosResponse: AxiosResponse) => {
       return Promise.resolve(axiosResponse.data);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,9 +5,18 @@ const Index: React.SFC = () => {
   return (
     <>
       <h1>🐱(=^・^=)🐱(=^・^=)🐱(=^・^=)🐱</h1>
-      <Link href="/counter">
-        <a>counter</a>
-      </Link>
+      <ul>
+        <li>
+          <Link href="/counter">
+            <a>counter</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/qiita">
+            <a>qiita</a>
+          </Link>
+        </li>
+      </ul>
     </>
   );
 };

--- a/src/pages/qiita.tsx
+++ b/src/pages/qiita.tsx
@@ -8,7 +8,6 @@ import { NextContext } from "next";
 interface IProps {
   actions: Dispatch<ReduxAction>;
   value: IQiitaState;
-  isServer: boolean;
 }
 
 export default class Qiita extends React.Component<IProps> {

--- a/src/pages/qiita.tsx
+++ b/src/pages/qiita.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { ReduxAction } from "../store";
-import { IQiitaState } from "../modules/Qiita";
+import { IQiitaState, qiitaActions } from "../modules/Qiita";
 import { Dispatch } from "redux";
 import QiitaContainer from "../containers/Qiita";
 import { NextContext } from "next";
 import { fetchUser } from "../domain/Qiita";
-import QiitaUser from "../components/QiitaUser";
 
 interface IProps {
   actions: Dispatch<ReduxAction>;
@@ -15,9 +14,13 @@ interface IProps {
 
 export default class Qiita extends React.Component<IProps> {
   static async getInitialProps(ctx: NextContext) {
-    const { err } = ctx;
+    const { err, isServer } = ctx;
     if (err != null) {
       // TODO 何らかのError処理を行う
+    }
+
+    if (!isServer) {
+      return;
     }
 
     const request = {
@@ -26,20 +29,13 @@ export default class Qiita extends React.Component<IProps> {
 
     const user = await fetchUser(request);
 
-    return {
-      value: {
-        id: request.id,
-        loading: false,
-        user
-      }
-    };
+    ctx.store.dispatch(qiitaActions.fetchUserSuccess(user));
   }
 
   render() {
     return (
       <>
         <QiitaContainer value={this.props.value} actions={this.props.actions} />
-        <QiitaUser value={this.props.value} />
       </>
     );
   }

--- a/src/pages/qiita.tsx
+++ b/src/pages/qiita.tsx
@@ -4,7 +4,6 @@ import { IQiitaState, qiitaActions } from "../modules/Qiita";
 import { Dispatch } from "redux";
 import QiitaContainer from "../containers/Qiita";
 import { NextContext } from "next";
-import { fetchUser } from "../domain/Qiita";
 
 interface IProps {
   actions: Dispatch<ReduxAction>;
@@ -27,9 +26,7 @@ export default class Qiita extends React.Component<IProps> {
       id: "keitakn"
     };
 
-    const user = await fetchUser(request);
-
-    ctx.store.dispatch(qiitaActions.fetchUserSuccess(user));
+    ctx.store.dispatch(qiitaActions.postFetchUserRequest(request));
   }
 
   render() {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/redux-next-boilerplate/issues/29

# 関連URL
http://localhost:3000/qiita

# Doneの定義
- https://github.com/nekochans/redux-next-boilerplate/issues/29 の現象が解決している事

# 変更点概要

## 技術的変更点概要
`getInitialProps` の際に `store.dispatch` を利用してQiitaのユーザー情報を取得するように変更。

これによってReduxに取得したユーザー情報が伝わるようになったので自然な形で実装が出来るようになった。