### PR TITLE
SSR時に表示されるタグの内容をカスタマイズ出来るように修正

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,9 +5,11 @@ import withRedux from "next-redux-wrapper";
 import withReduxSaga from "next-redux-saga";
 import configureStore, { IReduxState } from "../store";
 import { Store } from "redux";
+import Head from "next/head";
 
 interface IProps extends AppComponentProps {
   store: Store<IReduxState>;
+  pageProps: { title: string };
 }
 
 class MyApp extends App<IProps> {
@@ -23,6 +25,9 @@ class MyApp extends App<IProps> {
     const { Component, pageProps, store } = this.props;
     return (
       <Container>
+        <Head>
+          <title>{pageProps.title}</title>
+        </Head>
         <Provider store={store}>
           <Component {...pageProps} />
         </Provider>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import Document, {
+  Head,
+  Main,
+  NextDocumentContext,
+  NextScript
+} from "next/document";
+import { AppComponentProps } from "next/app";
+import { Store } from "redux";
+import { IReduxState } from "../store";
+
+interface IProps extends AppComponentProps {
+  store: Store<IReduxState>;
+}
+
+export default class MyDocument extends Document<IProps> {
+  static async getInitialProps(ctx: NextDocumentContext) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    return (
+      <html lang="ja">
+        <Head>
+          <meta charSet="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    );
+  }
+}

--- a/src/pages/counter.tsx
+++ b/src/pages/counter.tsx
@@ -3,13 +3,15 @@ import { ICounterState } from "../modules/Counter";
 import CounterContainer from "../containers/Counter";
 import { Dispatch } from "redux";
 import { ReduxAction } from "../store";
+import { compose, pure, setStatic } from "recompose";
+import { NextContext } from "next";
 
 interface IProps {
   actions: Dispatch<ReduxAction>;
   value: ICounterState;
 }
 
-export const Counter: React.SFC<IProps> = (props: IProps) => {
+export const CounterPage: React.SFC<IProps> = (props: IProps) => {
   return (
     <>
       <CounterContainer actions={props.actions} value={props.value} />
@@ -17,4 +19,18 @@ export const Counter: React.SFC<IProps> = (props: IProps) => {
   );
 };
 
-export default Counter;
+const enhancer = compose(
+  setStatic("getInitialProps", async (ctx: NextContext) => {
+    const { err } = ctx;
+    if (err != null) {
+      // TODO 何らかのError処理を行う
+    }
+
+    return {
+      title: "🐱カウンター🐱"
+    };
+  }),
+  pure
+);
+
+export default enhancer(CounterPage);

--- a/src/pages/counter.tsx
+++ b/src/pages/counter.tsx
@@ -19,7 +19,7 @@ export const CounterPage: React.SFC<IProps> = (props: IProps) => {
   );
 };
 
-const enhancer = compose(
+const enhance = compose(
   setStatic("getInitialProps", async (ctx: NextContext) => {
     const { err } = ctx;
     if (err != null) {
@@ -33,4 +33,4 @@ const enhancer = compose(
   pure
 );
 
-export default enhancer(CounterPage);
+export default enhance(CounterPage);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,7 @@ const IndexPage: React.SFC = () => {
   );
 };
 
-const enhancer = compose(
+const enhance = compose(
   setStatic("getInitialProps", async (ctx: NextContext) => {
     const { err } = ctx;
     if (err != null) {
@@ -37,4 +37,4 @@ const enhancer = compose(
   pure
 );
 
-export default enhancer(IndexPage);
+export default enhance(IndexPage);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+import { NextContext } from "next";
 import Link from "next/link";
+import { compose, pure, setStatic } from "recompose";
 
-const Index: React.SFC = () => {
+const IndexPage: React.SFC = () => {
   return (
     <>
       <h1>🐱(=^・^=)🐱(=^・^=)🐱(=^・^=)🐱</h1>
@@ -21,4 +23,18 @@ const Index: React.SFC = () => {
   );
 };
 
-export default Index;
+const enhancer = compose(
+  setStatic("getInitialProps", async (ctx: NextContext) => {
+    const { err } = ctx;
+    if (err != null) {
+      // TODO 何らかのError処理を行う
+    }
+
+    return {
+      title: "🐱ホーム画面🐱"
+    };
+  }),
+  pure
+);
+
+export default enhancer(IndexPage);

--- a/src/pages/qiita.tsx
+++ b/src/pages/qiita.tsx
@@ -26,8 +26,12 @@ const enhancer = compose(
       // TODO 何らかのError処理を行う
     }
 
+    const pageProps = {
+      title: "🐱Qiita ユーザー検索🐱"
+    };
+
     if (!isServer) {
-      return;
+      return pageProps;
     }
 
     const request = {
@@ -35,6 +39,8 @@ const enhancer = compose(
     };
 
     ctx.store.dispatch(qiitaActions.postFetchUserRequest(request));
+
+    return pageProps;
   }),
   pure
 );

--- a/src/pages/qiita.tsx
+++ b/src/pages/qiita.tsx
@@ -19,7 +19,7 @@ const QiitaPage: React.SFC<IProps> = (props: IProps) => {
   );
 };
 
-const enhancer = compose(
+const enhance = compose(
   setStatic("getInitialProps", async (ctx: NextContext) => {
     const { err, isServer } = ctx;
     if (err != null) {
@@ -45,4 +45,4 @@ const enhancer = compose(
   pure
 );
 
-export default enhancer(QiitaPage);
+export default enhance(QiitaPage);


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/redux-next-boilerplate/issues/37

# Doneの定義
- SSRの時にHeader要素が意図した物に書き換わっている事

# 変更点概要

## 技術的変更点概要
- `_document.tsx` を定義しHTMLタグの内容をカスタマイズ出来るように修正。
- 各ページComponentからページタイトルを返すように修正。