### PR TITLE
Qiitaのユーザー検索ページにスタイリングを適応

### DIFF
--- a/src/components/QiitaUser.tsx
+++ b/src/components/QiitaUser.tsx
@@ -1,15 +1,35 @@
 import React from "react";
 import { IQiitaState } from "../modules/Qiita";
+import styled from "styled-components";
 
 interface IProps {
   value: IQiitaState;
 }
 
+const QiitaUserCard = styled("div").attrs({ className: "card" })`
+  margin-top: 20px;
+`;
+
 const QiitaUser: React.SFC<IProps> = (props: IProps) => {
   return (
     <>
-      <p>{props.value.user.id}</p>
-      <img src={props.value.user.profile_image_url} />
+      <QiitaUserCard>
+        <div className="card-content">
+          <div className="media">
+            <div className="media-left">
+              <figure className="image is-48x48">
+                <img
+                  src={props.value.user.profile_image_url}
+                  alt="Placeholder image"
+                />
+              </figure>
+            </div>
+            <div className="media-content">
+              <p className="title is-4">{props.value.user.id}</p>
+            </div>
+          </div>
+        </div>
+      </QiitaUserCard>
     </>
   );
 };

--- a/src/components/QiitaUserForm.tsx
+++ b/src/components/QiitaUserForm.tsx
@@ -18,11 +18,25 @@ const QiitaUserForm: React.SFC<IProps> = (props: IProps) => {
   return (
     <>
       <form method="post" onSubmit={props.handleSubmit}>
-        <label>userId: </label>
-        <input type="text" name="id" onChange={props.handleChange} />
-        <button type="submit" value="Submit">
-          送信
-        </button>
+        <div className="field">
+          <label className="label">userId</label>
+          <div className="control">
+            <input
+              name="id"
+              className="input"
+              type="text"
+              placeholder="QiitaのユーザーIDを入れて下さい"
+              onChange={props.handleChange}
+            />
+          </div>
+        </div>
+        <div className="field is-grouped">
+          <div className="control">
+            <button type="submit" className="button is-link">
+              Submit
+            </button>
+          </div>
+        </div>
       </form>
       {props.value.user ? <QiitaUser value={props.value} /> : ""}
     </>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/redux-next-boilerplate/issues/51

# Doneの定義
- Qiitaユーザーの検索ページにスタイリングを適応

# スクリーンショット
![qiitauserform](https://user-images.githubusercontent.com/11032365/48303792-51f6ae00-e552-11e8-913a-1e86031baeb4.png)

# 変更点概要

## 技術的変更点概要
- Qiitaのユーザー検索フォームにスタイリングを適応