### PR TITLE
Cookieをクライアント、サーバー両方で扱えるように改修

### DIFF
--- a/src/components/MyPageButton.tsx
+++ b/src/components/MyPageButton.tsx
@@ -1,11 +1,14 @@
 import React from "react";
+import Link from "next/link";
 
 const MyPageButton: React.SFC<{}> = () => {
   return (
     <>
-      <a className="button is-primary" href="/my">
-        <strong>MyPage</strong>
-      </a>
+      <Link href="/my">
+        <a className="button is-primary">
+          <strong>MyPage</strong>
+        </a>
+      </Link>
     </>
   );
 };

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,8 +4,11 @@ import Link from "next/link";
 import LoginButton from "./LoginButton";
 import MyPageButton from "./MyPageButton";
 
-// TODO ログイン状態によってログインボタンの表示・非表示を切り替える
-export default () => {
+interface IProps {
+  isLoggedIn: boolean;
+}
+
+export default (props: IProps) => {
   return (
     <nav className="navbar" role="navigation" aria-label="main navigation">
       <div className="navbar-brand">
@@ -28,8 +31,7 @@ export default () => {
             <Link href="/qiita">
               <a className="button is-light">Qiita</a>
             </Link>
-            <LoginButton />
-            <MyPageButton />
+            {props.isLoggedIn ? <MyPageButton /> : <LoginButton />}
           </div>
         </div>
       </div>

--- a/src/infrastructure/cookie.ts
+++ b/src/infrastructure/cookie.ts
@@ -1,0 +1,15 @@
+import { NextContext } from "next";
+import Cookies from "universal-cookie";
+
+const cookies = (ctx: NextContext): Cookies => {
+  if (ctx.req) {
+    const { cookie = {} } = ctx.req.headers;
+    return new Cookies(cookie);
+  }
+
+  return new Cookies();
+};
+
+export const fetchFromCookie = (ctx: NextContext, key: string): string => {
+  return cookies(ctx).get(key);
+};

--- a/src/pages/counter.tsx
+++ b/src/pages/counter.tsx
@@ -7,16 +7,18 @@ import { compose, pure, setStatic } from "recompose";
 import { NextContext } from "next";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
+import { fetchFromCookie } from "../infrastructure/cookie";
 
 interface IProps {
   actions: Dispatch<ReduxAction>;
   value: ICounterState;
+  isLoggedIn: boolean;
 }
 
 export const CounterPage: React.SFC<IProps> = (props: IProps) => {
   return (
     <>
-      <Navbar />
+      <Navbar {...props} />
       <CounterContainer actions={props.actions} value={props.value} />
       <Footer />
     </>
@@ -30,8 +32,12 @@ const enhance = compose(
       // TODO 何らかのError処理を行う
     }
 
+    const accessToken = fetchFromCookie(ctx, "accessToken");
+    const isLoggedIn = accessToken != null;
+
     return {
-      title: "🐱カウンター🐱"
+      title: "🐱カウンター🐱",
+      isLoggedIn
     };
   }),
   pure

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,11 +4,16 @@ import { compose, pure, setStatic } from "recompose";
 import Title from "../components/Title";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
+import { fetchFromCookie } from "../infrastructure/cookie";
 
-const IndexPage: React.SFC = () => {
+interface IProps {
+  isLoggedIn: boolean;
+}
+
+const IndexPage: React.SFC<IProps> = (props: IProps) => {
   return (
     <>
-      <Navbar />
+      <Navbar {...props} />
       <Title title="🐱(=^・^=)🐱ホーム🐱(=^・^=)🐱" />
       <Footer />
     </>
@@ -22,8 +27,12 @@ const enhance = compose(
       // TODO 何らかのError処理を行う
     }
 
+    const accessToken = fetchFromCookie(ctx, "accessToken");
+    const isLoggedIn = accessToken != null;
+
     return {
-      title: "🐱ホーム画面🐱"
+      title: "🐱ホーム画面🐱",
+      isLoggedIn
     };
   }),
   pure

--- a/src/pages/my.tsx
+++ b/src/pages/my.tsx
@@ -8,7 +8,6 @@ import { ReduxAction } from "../store";
 import { IMyState, myActions } from "../modules/My";
 import { NextContext } from "next";
 import { fetchFromCookie } from "../infrastructure/cookie";
-import Router from "next/router";
 
 interface IProps {
   actions: Dispatch<ReduxAction>;
@@ -21,7 +20,11 @@ const MyPage: React.SFC<IProps> = (props: IProps) => {
   return (
     <>
       <Navbar {...props} />
-      <MyContainer value={props.value} actions={props.actions} />
+      {props.isLoggedIn ? (
+        <MyContainer value={props.value} actions={props.actions} />
+      ) : (
+        <h2 className="title is-3">🐱ログインを行って下さい🐱</h2>
+      )}
       <Footer />
     </>
   );
@@ -29,21 +32,19 @@ const MyPage: React.SFC<IProps> = (props: IProps) => {
 
 const enhance = compose(
   setStatic("getInitialProps", async (ctx: NextContext) => {
-    const { err, isServer } = ctx;
+    const { err } = ctx;
     if (err != null) {
       // TODO 何らかのError処理を行う
     }
 
     const accessToken = fetchFromCookie(ctx, "accessToken");
-    if (accessToken == null && !isServer) {
-      return await Router.push("/");
-    }
+    const isLoggedIn = accessToken != null;
 
     const pageProps = {
       actions: ctx.store.dispatch,
       value: ctx.store.getState(),
       title: "🐱Myアカウント🐱",
-      isLoggedIn: true
+      isLoggedIn
     };
 
     ctx.store.dispatch(

--- a/src/pages/my.tsx
+++ b/src/pages/my.tsx
@@ -7,6 +7,7 @@ import { Dispatch } from "redux";
 import { ReduxAction } from "../store";
 import { IMyState, myActions } from "../modules/My";
 import { NextContext } from "next";
+import { fetchFromCookie } from "../infrastructure/cookie";
 
 interface IProps {
   actions: Dispatch<ReduxAction>;
@@ -30,9 +31,8 @@ const enhance = compose(
       // TODO 何らかのError処理を行う
     }
 
-    const accessToken = ctx.req["cookies"].accessToken;
+    const accessToken = fetchFromCookie(ctx, "accessToken");
     if (accessToken == null) {
-      // TODO 何らかのError処理を行う
     }
 
     const pageProps = {

--- a/src/pages/my.tsx
+++ b/src/pages/my.tsx
@@ -8,16 +8,19 @@ import { ReduxAction } from "../store";
 import { IMyState, myActions } from "../modules/My";
 import { NextContext } from "next";
 import { fetchFromCookie } from "../infrastructure/cookie";
+import Router from "next/router";
 
 interface IProps {
   actions: Dispatch<ReduxAction>;
   value: IMyState;
+  title: string;
+  isLoggedIn: boolean;
 }
 
 const MyPage: React.SFC<IProps> = (props: IProps) => {
   return (
     <>
-      <Navbar />
+      <Navbar {...props} />
       <MyContainer value={props.value} actions={props.actions} />
       <Footer />
     </>
@@ -26,17 +29,21 @@ const MyPage: React.SFC<IProps> = (props: IProps) => {
 
 const enhance = compose(
   setStatic("getInitialProps", async (ctx: NextContext) => {
-    const { err } = ctx;
+    const { err, isServer } = ctx;
     if (err != null) {
       // TODO 何らかのError処理を行う
     }
 
     const accessToken = fetchFromCookie(ctx, "accessToken");
-    if (accessToken == null) {
+    if (accessToken == null && !isServer) {
+      return await Router.push("/");
     }
 
     const pageProps = {
-      title: "🐱Myアカウント🐱"
+      actions: ctx.store.dispatch,
+      value: ctx.store.getState(),
+      title: "🐱Myアカウント🐱",
+      isLoggedIn: true
     };
 
     ctx.store.dispatch(

--- a/src/pages/qiita.tsx
+++ b/src/pages/qiita.tsx
@@ -7,16 +7,18 @@ import { NextContext } from "next";
 import { compose, setStatic, pure } from "recompose";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
+import { fetchFromCookie } from "../infrastructure/cookie";
 
 interface IProps {
   actions: Dispatch<ReduxAction>;
   value: IQiitaState;
+  isLoggedIn: boolean;
 }
 
 const QiitaPage: React.SFC<IProps> = (props: IProps) => {
   return (
     <>
-      <Navbar />
+      <Navbar {...props} />
       <QiitaContainer value={props.value} actions={props.actions} />
       <Footer />
     </>
@@ -30,8 +32,12 @@ const enhance = compose(
       // TODO 何らかのError処理を行う
     }
 
+    const accessToken = fetchFromCookie(ctx, "accessToken");
+    const isLoggedIn = accessToken != null;
+
     const pageProps = {
-      title: "🐱Qiita ユーザー検索🐱"
+      title: "🐱Qiita ユーザー検索🐱",
+      isLoggedIn
     };
 
     if (!isServer) {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -101,8 +101,7 @@ const app = (next: next.Server): express.Express => {
       await issueAccessToken(req.query.code)
         .then(tokenResponse => {
           res.cookie("accessToken", tokenResponse.token, {
-            path: "/",
-            httpOnly: true
+            path: "/"
           });
 
           return res.status(302).redirect(`${appUrl()}/my`);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -77,7 +77,10 @@ const app = (next: next.Server): express.Express => {
   // Qiitaの認可サーバーへリクエスト
   app.get("/oauth/request", (req: express.Request, res: express.Response) => {
     const authorizationState = createAuthorizationState();
-    res.cookie("authorizationState", authorizationState);
+    res.cookie("authorizationState", authorizationState, {
+      path: "/",
+      httpOnly: true
+    });
 
     return res.redirect(302, createAuthorizationUrl(authorizationState));
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,9 +763,9 @@
   integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
 
 "@emotion/unitless@^0.7.0":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.2.tgz#b180097bb44a40c3b59efea9cf28df2fe542d518"
-  integrity sha512-mK4SHgIiJiwRZyenDXlaLUdR7vm8xUvJ4VYmpWNTDtF3ykEbI1XNVcbhAZwt07xjtCvLenoJMP8Eqx1FXvoWDQ==
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
+  integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
 
 "@fimbul/bifrost@^0.15.0":
   version "0.15.0"
@@ -893,9 +893,9 @@
     "@types/react" "*"
 
 "@types/node-fetch@*":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.1.3.tgz#80538fbaee61bdc01449f4e00a11e11291e52dec"
-  integrity sha512-3P5f1st1wfjtA97KxQNK8ul1y+bM0b/+bMVPl3anPsdmOm794CQh3lRzphlFqTcJP01NtYDda/F/pbSbYUChmQ==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.1.4.tgz#093d1beae11541aef25999d70aa09286fd025b1a"
+  integrity sha512-tR1ekaXUGpmzOcDXWU9BW73YfA2/VW1DF1FH+wlJ82BbCSnWTbdX+JkqWQXWKIGsFPnPsYadbXfNgz28g+ccWg==
   dependencies:
     "@types/node" "*"
 
@@ -2111,15 +2111,20 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
+camelcase@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+
 camelize@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000898, caniuse-lite@^1.0.30000899:
-  version "1.0.30000907"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000907.tgz#0b9899bde53fb1c30e214fb12402361e02ff5c42"
-  integrity sha512-No5sQ/OB2Nmka8MNOOM6nJx+Hxt6MQ6h7t7kgJFu9oTuwjykyKRSBP/+i/QAyFHxeHB+ddE0Da1CG5ihx9oehQ==
+  version "1.0.30000909"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000909.tgz#697e8f447ca5f758e7c6cef39ec429ce18b908d3"
+  integrity sha512-4Ix9ArKpo3s/dLGVn/el9SAk6Vn2kGhg8XeE4eRTsGEsmm9RnTkwnBsVZs7p4wA8gB+nsgP36vZWYbG8a4nYrg==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -2384,15 +2389,15 @@ concat-stream@^1.5.0:
     typedarray "^0.0.6"
 
 concurrently@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-4.0.1.tgz#f6310fbadf2f476dd95df952edb5c0ab789f672c"
-  integrity sha512-D8UI+mlI/bfvrA57SeKOht6sEpb01dKk+8Yee4fbnkk1Ue8r3S+JXoEdFZIpzQlXJGtnxo47Wvvg/kG4ba3U6Q==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-4.1.0.tgz#17fdf067da71210685d9ea554423ef239da30d33"
+  integrity sha512-pwzXCE7qtOB346LyO9eFWpkFJVO3JQZ/qU/feGeaAHiX1M3Rw3zgXKc5cZ8vSH5DGygkjzLFDzA/pwoQDkRNGg==
   dependencies:
     chalk "^2.4.1"
     date-fns "^1.23.0"
     lodash "^4.17.10"
     read-pkg "^4.0.1"
-    rxjs "6.2.2"
+    rxjs "^6.3.3"
     spawn-command "^0.0.2-1"
     supports-color "^4.5.0"
     tree-kill "^1.1.0"
@@ -2787,17 +2792,10 @@ decamelize-keys@^1.0.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
-
-decamelize@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-2.0.0.tgz#656d7bbc8094c4c788ea53c5840908c9c7d063c7"
-  integrity sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==
-  dependencies:
-    xregexp "4.0.0"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -3643,9 +3641,9 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.0.4"
 
 follow-redirects@^1.3.0:
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.9.tgz#c9ed9d748b814a39535716e531b9196a845d89c6"
-  integrity sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"
 
@@ -6299,9 +6297,9 @@ node-pre-gyp@^0.10.0:
     tar "^4"
 
 node-releases@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.3.tgz#3414ed84595096459c251699bfcb47d88324a9e4"
-  integrity sha512-ZaZWMsbuDcetpHmYeKWPO6e63pSXLb50M7lJgCbcM2nC/nQC3daNifmtp5a2kp7EWwYfhuvH6zLPWkrF8IiDdw==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.4.tgz#2d585de8c6c81d00017e063e7810a63889aa6756"
+  integrity sha512-GqRV9GcHw8JCRDaP/JoeNMNzEGzHAknMvIHqMb2VeTOmg1Cf9+ej8bkV12tHfzWHQMCkQ5zUFgwFUkfraynNCw==
   dependencies:
     semver "^5.3.0"
 
@@ -7105,9 +7103,9 @@ postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.17, postcss@^6.0.23, postcss@^6.0.
     supports-color "^5.4.0"
 
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.2, postcss@^7.0.3, postcss@^7.0.5:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.5.tgz#70e6443e36a6d520b0fd4e7593fcca3635ee9f55"
-  integrity sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.6.tgz#6dcaa1e999cdd4a255dcd7d4d9547f4ca010cdc2"
+  integrity sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==
   dependencies:
     chalk "^2.4.1"
     source-map "^0.6.1"
@@ -7971,10 +7969,10 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.2.tgz#eb75fa3c186ff5289907d06483a77884586e1cf9"
-  integrity sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==
+rxjs@^6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
   dependencies:
     tslib "^1.9.0"
 
@@ -9241,9 +9239,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript-fsa-reducers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-fsa-reducers/-/typescript-fsa-reducers-1.0.0.tgz#1503fcdec38f70377aab79a15ea737cdfeb803c1"
-  integrity sha512-tD37fxOKQVndBi0PrN54AK387saJCyBQr+gZMi9eUQ9Py/WPyrFGuqO12dsKIt94bzyhB2BLcnMJoy/TrGkUKg==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/typescript-fsa-reducers/-/typescript-fsa-reducers-1.1.0.tgz#b6f00e515a7fe2ad319a6f4f8e642b205405b1c2"
+  integrity sha512-LDeuwrNwuqyZMJsxP8pJUCDuBMK504VG0j51sImLMZjgDbPD/WSEbZPS++cFVzN+FnGS25iTO7HFfQ3JHWVx5A==
 
 typescript-fsa@^3.0.0-beta-2:
   version "3.0.0-beta-2"
@@ -9553,14 +9551,14 @@ verror@1.10.0:
     extsprintf "^1.2.0"
 
 vfile-location@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.3.tgz#083ba80e50968e8d420be49dd1ea9a992131df77"
-  integrity sha512-zM5/l4lfw1CBoPx3Jimxoc5RNDAHHpk6AM6LM0pTIkm5SUSsx8ZekZ0PVdf0WEZ7kjlhSt7ZlqbRL6Cd6dBs6A==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.4.tgz#2a5e7297dd0d9e2da4381464d04acc6b834d3e55"
+  integrity sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w==
 
 vfile-message@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.1.tgz#51a2ccd8a6b97a7980bb34efb9ebde9632e93677"
-  integrity sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.2.tgz#0f8a62584c5dff0f81760531b8e34f3cea554ebc"
+  integrity sha512-dNdEXHfPCvzyOlEaaQ+DcXpcxEz+pFvdrebKLiAMjobjaBC2bMeWoHOKPwJ+I8A4jQOEUDH7uoVcLWDLF1qhVQ==
   dependencies:
     unist-util-stringify-position "^1.1.1"
 
@@ -9873,11 +9871,6 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xregexp@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
-  integrity sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==
-
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
@@ -9903,12 +9896,20 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
   integrity sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=
 
-yargs-parser@10.x, yargs-parser@^10.0.0, yargs-parser@^10.1.0:
+yargs-parser@10.x, yargs-parser@^10.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^5.0.0:
   version "5.0.0"
@@ -9943,12 +9944,12 @@ yargs@^11.0.0:
     yargs-parser "^9.0.2"
 
 yargs@^12.0.1:
-  version "12.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.2.tgz#fe58234369392af33ecbef53819171eff0f5aadc"
-  integrity sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
+  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
   dependencies:
     cliui "^4.0.0"
-    decamelize "^2.0.0"
+    decamelize "^1.2.0"
     find-up "^3.0.0"
     get-caller-file "^1.0.1"
     os-locale "^3.0.0"
@@ -9958,7 +9959,7 @@ yargs@^12.0.1:
     string-width "^2.0.0"
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
-    yargs-parser "^10.1.0"
+    yargs-parser "^11.1.1"
 
 yargs@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/redux-next-boilerplate/issues/43

# Doneの定義
- Cookieがサーバーサイド、クライアントサイドの両方で扱えるようになっている事
- Myページにログイン状態でないとアクセス出来ない状態になっている事

# 変更点概要

## 仕様的変更点概要
- 未ログイン状態でMyページに遷移するとログインを促すメッセージが表示されるようになった
- サーバー側のCookie設定オプションを見直し

## 技術的変更点概要
- `universal-cookie` でクライアントサイドでもCookieを取得出来るように改修

# 補足
以下の点は改善が必要なので次回以降のPRで対応していく。

- ログイン判定処理が複数箇所に散らばっている
- 全てのページComponentがTitle, ログイン状態を持っているので共通管理出来るようにする