### PR TITLE
Layout用のComponentを作成

### DIFF
--- a/src/components/Counter.tsx
+++ b/src/components/Counter.tsx
@@ -23,7 +23,7 @@ const DecrementButton = styled("button").attrs({
   className: "button is-danger"
 })``;
 
-export const Counter: React.SFC<IProps> = (props: IProps) => {
+export const Counter: React.FunctionComponent<IProps> = (props: IProps) => {
   return (
     <>
       <CountResult>🐱 {props.value.count} 🐱</CountResult>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Navbar from "./Navbar";
+import Footer from "./Footer";
+import { IReduxState } from "../store";
+
+interface IProps {
+  value: IReduxState;
+  children: React.ReactNode;
+}
+
+const Layout = (props: IProps) => {
+  return (
+    <>
+      <Navbar value={props.value} />
+      {props.children}
+      <Footer />
+    </>
+  );
+};
+
+export default Layout;

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const LoginButton: React.SFC<{}> = () => {
+const LoginButton: React.FunctionComponent<{}> = () => {
   return (
     <>
       <a className="button is-primary" href="/oauth/request">

--- a/src/components/MyPageButton.tsx
+++ b/src/components/MyPageButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Link from "next/link";
 
-const MyPageButton: React.SFC<{}> = () => {
+const MyPageButton: React.FunctionComponent<{}> = () => {
   return (
     <>
       <Link href="/my">

--- a/src/components/QiitaUser.tsx
+++ b/src/components/QiitaUser.tsx
@@ -10,7 +10,7 @@ const QiitaUserCard = styled("div").attrs({ className: "card" })`
   margin-top: 20px;
 `;
 
-const QiitaUser: React.SFC<IProps> = (props: IProps) => {
+const QiitaUser: React.FunctionComponent<IProps> = (props: IProps) => {
   return (
     <>
       <QiitaUserCard>

--- a/src/components/QiitaUserForm.tsx
+++ b/src/components/QiitaUserForm.tsx
@@ -14,7 +14,7 @@ interface IProps {
   handleChange: () => {};
 }
 
-const QiitaUserForm: React.SFC<IProps> = (props: IProps) => {
+const QiitaUserForm: React.FunctionComponent<IProps> = (props: IProps) => {
   return (
     <>
       <form method="post" onSubmit={props.handleSubmit}>

--- a/src/pages/counter.tsx
+++ b/src/pages/counter.tsx
@@ -4,8 +4,7 @@ import { Dispatch } from "redux";
 import { IReduxState, ReduxAction } from "../store";
 import { compose, pure, setStatic } from "recompose";
 import { NextContext } from "next";
-import Navbar from "../components/Navbar";
-import Footer from "../components/Footer";
+import Layout from "../components/Layout";
 import { isLoggedIn } from "../domain/Auth";
 import { rootActions } from "../modules/Root";
 
@@ -16,11 +15,9 @@ interface IProps {
 
 export const CounterPage: React.SFC<IProps> = (props: IProps) => {
   return (
-    <>
-      <Navbar value={props.value} />
+    <Layout value={props.value}>
       <CounterContainer actions={props.actions} value={props.value} />
-      <Footer />
-    </>
+    </Layout>
   );
 };
 

--- a/src/pages/counter.tsx
+++ b/src/pages/counter.tsx
@@ -13,7 +13,7 @@ interface IProps {
   value: IReduxState;
 }
 
-export const CounterPage: React.SFC<IProps> = (props: IProps) => {
+export const CounterPage: React.FunctionComponent<IProps> = (props: IProps) => {
   return (
     <Layout value={props.value}>
       <CounterContainer actions={props.actions} value={props.value} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,7 @@ interface IProps {
   value: IReduxState;
 }
 
-const IndexPage: React.SFC<IProps> = (props: IProps) => {
+const IndexPage: React.FunctionComponent<IProps> = (props: IProps) => {
   return (
     <Layout value={props.value}>
       <Title title={props.value.root.title} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,11 +2,10 @@ import React from "react";
 import { NextContext } from "next";
 import { compose, pure, setStatic } from "recompose";
 import Title from "../components/Title";
-import Navbar from "../components/Navbar";
-import Footer from "../components/Footer";
 import { rootActions } from "../modules/Root";
 import { isLoggedIn } from "../domain/Auth";
 import { IReduxState } from "../store";
+import Layout from "../components/Layout";
 
 interface IProps {
   value: IReduxState;
@@ -14,11 +13,9 @@ interface IProps {
 
 const IndexPage: React.SFC<IProps> = (props: IProps) => {
   return (
-    <>
-      <Navbar value={props.value} />
+    <Layout value={props.value}>
       <Title title={props.value.root.title} />
-      <Footer />
-    </>
+    </Layout>
   );
 };
 

--- a/src/pages/my.tsx
+++ b/src/pages/my.tsx
@@ -14,7 +14,7 @@ interface IProps {
   value: IReduxState;
 }
 
-const MyPage: React.SFC<IProps> = (props: IProps) => {
+const MyPage: React.FunctionComponent<IProps> = (props: IProps) => {
   return (
     <Layout value={props.value}>
       {props.value.root.isLoggedIn ? (

--- a/src/pages/my.tsx
+++ b/src/pages/my.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { compose, setStatic, pure } from "recompose";
-import Navbar from "../components/Navbar";
-import Footer from "../components/Footer";
+import Layout from "../components/Layout";
 import MyContainer from "../containers/My";
 import { Dispatch } from "redux";
 import { IReduxState, ReduxAction } from "../store";
@@ -17,15 +16,13 @@ interface IProps {
 
 const MyPage: React.SFC<IProps> = (props: IProps) => {
   return (
-    <>
-      <Navbar value={props.value} />
+    <Layout value={props.value}>
       {props.value.root.isLoggedIn ? (
         <MyContainer value={props.value} actions={props.actions} />
       ) : (
         <h2 className="title is-3">🐱ログインを行って下さい🐱</h2>
       )}
-      <Footer />
-    </>
+    </Layout>
   );
 };
 

--- a/src/pages/qiita.tsx
+++ b/src/pages/qiita.tsx
@@ -5,8 +5,7 @@ import { Dispatch } from "redux";
 import QiitaContainer from "../containers/Qiita";
 import { NextContext } from "next";
 import { compose, setStatic, pure } from "recompose";
-import Navbar from "../components/Navbar";
-import Footer from "../components/Footer";
+import Layout from "../components/Layout";
 import { isLoggedIn } from "../domain/Auth";
 import { rootActions } from "../modules/Root";
 
@@ -17,11 +16,9 @@ interface IProps {
 
 const QiitaPage: React.SFC<IProps> = (props: IProps) => {
   return (
-    <>
-      <Navbar value={props.value} />
+    <Layout value={props.value}>
       <QiitaContainer value={props.value} actions={props.actions} />
-      <Footer />
-    </>
+    </Layout>
   );
 };
 

--- a/src/pages/qiita.tsx
+++ b/src/pages/qiita.tsx
@@ -14,7 +14,7 @@ interface IProps {
   value: IReduxState;
 }
 
-const QiitaPage: React.SFC<IProps> = (props: IProps) => {
+const QiitaPage: React.FunctionComponent<IProps> = (props: IProps) => {
   return (
     <Layout value={props.value}>
       <QiitaContainer value={props.value} actions={props.actions} />


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/redux-next-boilerplate/issues/62

# Doneの定義
- Layout用のComponentが作成され各ページComponentが置き換わっている事

# 変更点概要

## 技術的変更点概要
Layout用のComponentを定義して各ページComponentを置き換えた。

# 補足情報
本件とは直接関係はないが、React.SFCの型定義が非推奨になっていたのでReact.FunctionComponentに変更。
